### PR TITLE
Handle unexported fields

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -179,7 +179,12 @@ func (mv *Validator) Validate(v interface{}) (bool, map[string][]error) {
 		if tag == "" && f.Kind() != reflect.Struct {
 			continue
 		}
-		fname := st.Field(i).Name
+		var fieldInfo = st.Field(i)
+		if len(fieldInfo.PkgPath) != 0 { // unexported field
+			continue
+		}
+		fname := fieldInfo.Name
+
 		var errs []error
 		switch f.Kind() {
 		case reflect.Struct:


### PR DESCRIPTION
The validator would panic on recursively validating e.g. a time.Time field which has unexported fields.
