### PR TITLE
correct documentation: tagName should be validate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Then it is possible to use the notzz validation tag. This will print
 "Field A error: value cannot be ZZ"
 
 	type T struct {
-		A string  `validator:"nonzero,notzz"`
+		A string  `validate:"nonzero,notzz"`
 	}
 	t := T{"ZZ"}
 	if valid, errs := validator.Validate(t); !valid {


### PR DESCRIPTION
Default branch (v1) still uses "validator" for all tagNames, I was very confused...
