### PR TITLE
validator.Validate() returns `error`, not `bool, error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A simple example would be.
 	}
 
 	nur := NewUserRequest{Username: "something", Age: 20}
-	if valid, errs := validator.Validate(nur); !valid {
+	if err := validator.Validate(nur); err != nil {
 		// values not valid, deal with errors here
 	}
 
@@ -99,7 +99,7 @@ Then it is possible to use the notzz validation tag. This will print
 		A string  `validate:"nonzero,notzz"`
 	}
 	t := T{"ZZ"}
-	if valid, errs := validator.Validate(t); !valid {
+	if err := validator.Validate(t); err != nil {
 		fmt.Printf("Field A error: %s\n", errs["A"][0])
 	}
 


### PR DESCRIPTION
Fix the README.md, since Validate() doesn't return a `bool, error` any more, it now returns just `error`.