### PR TITLE
Allow interfaces to be validated

### DIFF
--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/codeship/validator"
+	"gopkg.in/validator.v2"
 )
 
 // This example demonstrates a custom function to process template text.

--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sort"
 
-	"gopkg.in/validator.v2"
+	"github.com/codeship/validator"
 )
 
 // This example demonstrates a custom function to process template text.

--- a/validator.go
+++ b/validator.go
@@ -202,7 +202,7 @@ func (mv *Validator) Validate(v interface{}) error {
 	if sv.Kind() == reflect.Ptr && !sv.IsNil() {
 		return mv.Validate(sv.Elem().Interface())
 	}
-	if sv.Kind() != reflect.Struct {
+	if sv.Kind() != reflect.Struct && sv.Kind() != reflect.Interface {
 		return ErrUnsupported
 	}
 
@@ -217,20 +217,20 @@ func (mv *Validator) Validate(v interface{}) error {
 		tag := st.Field(i).Tag.Get(mv.tagName)
 		if f.Kind() == reflect.Ptr {
 			ff := f.Elem()
-			if ff.Kind() == reflect.Struct {
+			if ff.Kind() == reflect.Struct || ff.Kind() == reflect.Interface {
 
 			}
 		}
 		if tag == "-" {
 			continue
 		}
-		if tag == "" && f.Kind() != reflect.Struct {
+		if tag == "" && f.Kind() != reflect.Struct && f.Kind() != reflect.Interface {
 			continue
 		}
 		fname := st.Field(i).Name
 		var errs ErrorArray
 		switch f.Kind() {
-		case reflect.Struct:
+		case reflect.Struct, reflect.Interface:
 			if !unicode.IsUpper(rune(fname[0])) {
 				continue
 			}

--- a/validator_test.go
+++ b/validator_test.go
@@ -35,6 +35,18 @@ type Simple struct {
 	A int `validate:"min=10"`
 }
 
+type I interface {
+	Foo() string
+}
+
+type Impl struct {
+	F string `validate:"len=3"`
+}
+
+func (this *Impl) Foo() string {
+	return this.F
+}
+
 type TestStruct struct {
 	A   int    `validate:"nonzero"`
 	B   string `validate:"len=8,min=6,max=4"`
@@ -45,6 +57,7 @@ type TestStruct struct {
 		D *string `validate:"nonzero"`
 	}
 	D *Simple `validate:"nonzero"`
+	E I       `validate:nonzero`
 }
 
 func (ms *MySuite) TestValidate(c *C) {
@@ -56,6 +69,7 @@ func (ms *MySuite) TestValidate(c *C) {
 	t.Sub.B = ""
 	t.Sub.C = 0.0
 	t.D = &Simple{10}
+	t.E = &Impl{"hello"}
 
 	err := validator.Validate(t)
 	c.Assert(err, NotNil)
@@ -70,6 +84,7 @@ func (ms *MySuite) TestValidate(c *C) {
 	c.Assert(errs["Sub.B"], HasLen, 0)
 	c.Assert(errs["Sub.C"], HasLen, 2)
 	c.Assert(errs["Sub.D"], HasError, validator.ErrZeroValue)
+	c.Assert(errs["E.F"], HasError, validator.ErrLen)
 }
 
 func (ms *MySuite) TestValidSlice(c *C) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -19,8 +19,8 @@ package validator_test
 import (
 	"testing"
 
+	"github.com/codeship/validator"
 	. "gopkg.in/check.v1"
-	"gopkg.in/validator.v2"
 )
 
 func Test(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -19,8 +19,8 @@ package validator_test
 import (
 	"testing"
 
-	"github.com/codeship/validator"
 	. "gopkg.in/check.v1"
+	"gopkg.in/validator.v2"
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
This works the same as structs, but if an interface implementation has unexported fields that are validated, this will panic.