### PR TITLE
Introduce nop validator for '-' tag to explicitly switch off validating ...

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -213,6 +213,12 @@ func regex(v interface{}, param string) error {
 	return nil
 }
 
+// nop is a validate func that explicitly
+// returns no error
+func nop(v interface{}, param string) error {
+	return nil
+}
+
 // asInt retuns the parameter as a int64
 // or panics if it can't convert
 func asInt(param string) (int64, error) {

--- a/validator.go
+++ b/validator.go
@@ -126,6 +126,7 @@ func NewValidator() *Validator {
 			"min":     min,
 			"max":     max,
 			"regexp":  regex,
+			"-":       nop,
 		},
 	}
 }


### PR DESCRIPTION
This is usefull if you want to explicitly exclude struct members that have validating on their own.
by Example:

```
type BaseData struct {
	Id       string         `toml:"id" validate:"nonzero"`
	Name     string         ` toml:"name" validate:"nonzero"`
	MimeType string         `toml:"mimetype"`
}

type Criteria struct {
	BaseData `toml:"Base"` //this gets validated
	Template BaseData `toml:"templ" validate:"-"` //this is skipped
}
```






