### PR TITLE
Structs in slice/array are not being validated

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -365,6 +365,36 @@ func (ms *MySuite) TestValidateSliceInStructWithTag(c *C) {
 	c.Assert(errs["Y[0].A"], HasError, validator.ErrZeroValue)
 }
 
+func (ms *MySuite) TestValidateStructInInterface(c *C) {
+	type sa struct {
+		A string `validate:"nonzero"`
+	}
+	type test struct {
+		X interface{}
+		Y interface{}
+		Z []interface{}
+	}
+	t := test{}
+	var ival int = 1
+	var sval string = "val"
+	t.X = &sa{}
+	t.Y = &ival
+	t.Z = []interface{}{&sval, sa{}, sa{"test"}}
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs, HasLen, 2)
+	c.Assert(errs["X.A"], HasError, validator.ErrZeroValue)
+	c.Assert(errs["Z[1].A"], HasError, validator.ErrZeroValue)
+
+	t.X = &sa{"sa"}
+	t.Y = ival
+	t.Z = []interface{}{sval}
+	err = validator.Validate(t)
+	c.Assert(err, IsNil)
+}
+
 type hasErrorChecker struct {
 	*CheckerInfo
 }


### PR DESCRIPTION
```go
package main

import (
	"fmt"

	"gopkg.in/validator.v2"
)

type A struct {
	A string `validate:"nonzero"`
}

type B struct {
	B []A
}

func main() {
	a := A{}
	b := B{
		B: []A{a},
	}
	c := []A{a}

	v := validator.NewValidator()
	err := v.Validate(&a)
	fmt.Printf("validate A: %v\n", err)
	err = v.Validate(&b)
	fmt.Printf("validate B: %v\n", err)
	err = v.Validate(&c)
	fmt.Printf("validate []A: %v\n", err)
}
```

I would expect an error is returned on `v.Validate(&b)`, but the `Validate` returns nil actually:
```
validate A: A: zero value
validate B: <nil>
validate []A: unsupported type
```