### PR TITLE
README/v2: fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A simple example would be.
 	}
 
 	nur := NewUserRequest{Username: "something", Age: 20}
-	if valid, errs := validator.Validate(nur); !valid {
+	if err := validator.Validate(nur); err != nil {
 		// values not valid, deal with errors here
 	}
 


### PR DESCRIPTION
Fixed legacy usage example with assignment counts.

Otherwise, this error
```shell
: assignment count mismatch: 2 = 1
```