### PR TITLE
Fix example test ExampleValidate to rely on deterministic output.

### DIFF
--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -18,6 +18,7 @@ package validator_test
 
 import (
 	"fmt"
+	"sort"
 
 	"gopkg.in/validator.v1"
 )
@@ -59,19 +60,27 @@ func ExampleValidate() {
 			fmt.Println("Street cannot be empty.")
 		}
 
+		var keys []string
+		for k := range errs {
+			keys = append(keys, k)
+		}
+
+		// Sorting such that there is deterministic output for testing
+		sort.Strings(keys)
+
 		// Iterate through the list of fields and respective errors
 		fmt.Println("Invalid due to fields:")
-		for f, e := range errs {
-			fmt.Printf("\t - %s (%v)\n", f, e)
+		for _, k := range keys {
+			fmt.Printf("\t - %s (%v)\n", k, errs[k])
 		}
 	}
 
 	// Output:
 	// Street cannot be empty.
 	// Invalid due to fields:
+	//	 - Address.Street ([zero value])
 	//	 - Age ([less than min])
 	//	 - Email ([regular expression mismatch])
-	//	 - Address.Street ([zero value])
 }
 
 // This example shows how to use the Valid helper


### PR DESCRIPTION
Was running the test suite and found that ExampleValidate() in examplevalidate_test.go would fail after being run several times:

```bash
zamn at zig in ~/code/go/src/github.com/go-validator/validator on master using 2.2.3
± while true ;do go test . ;done
ok      github.com/go-validator/validator       0.009s
ok      github.com/go-validator/validator       0.008s
ok      github.com/go-validator/validator       0.009s
OK: 10 passed
--- FAIL: ExampleValidate (0.00s)
got:
Street cannot be empty.
Invalid due to fields:
         - Email ([regular expression mismatch])
         - Address.Street ([zero value])
         - Age ([less than min])
want:
Street cannot be empty.
Invalid due to fields:
         - Age ([less than min])
         - Email ([regular expression mismatch])
         - Address.Street ([zero value])
FAIL
FAIL    github.com/go-validator/validator       0.008s
ok      github.com/go-validator/validator       0.008s
OK: 10 passed
--- FAIL: ExampleValidate (0.00s)
got:
Street cannot be empty.
Invalid due to fields:
         - Address.Street ([zero value])
         - Age ([less than min])
         - Email ([regular expression mismatch])
want:
Street cannot be empty.
Invalid due to fields:
         - Address.Street ([zero value])
         - Age ([less than min])
         - Email ([regular expression mismatch])
want:
Street cannot be empty.
Invalid due to fields:
         - Age ([less than min])
         - Email ([regular expression mismatch])
         - Address.Street ([zero value])
FAIL
FAIL    github.com/go-validator/validator       0.008s
ok      github.com/go-validator/validator       0.009s
ok      github.com/go-validator/validator       0.008s
```

This is because the return order of the validator is non-deterministic. To fix this I sorted the keys, thus making it deterministic and testable. New Output:
```bash
zamn at zig in ~/code/go/src/github.com/zamN/validator on master! using 2.2.3
± while true ;do go test .; done
ok      github.com/zamN/validator       0.009s
ok      github.com/zamN/validator       0.007s
ok      github.com/zamN/validator       0.008s
ok      github.com/zamN/validator       0.007s
ok      github.com/zamN/validator       0.008s
ok      github.com/zamN/validator       0.007s
ok      github.com/zamN/validator       0.008s
ok      github.com/zamN/validator       0.011s
ok      github.com/zamN/validator       0.008s
ok      github.com/zamN/validator       0.008s
ok      github.com/zamN/validator       0.011s
ok      github.com/zamN/validator       0.011s
ok      github.com/zamN/validator       0.009s
ok      github.com/zamN/validator       0.007s
```