### PR TITLE
Fix nonzero handling of structs after #38 was merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Here is the list of validators buildin in the package.
 	nonzero
 		This validates that the value is not zero. The appropriate
 		zero value is given by the Go spec (e.g. for int it's 0, for
-		string it's "", for pointers is nil, etc.) Usage: nonzero
+		string it's "", for pointers is nil, etc.) For structs, it
+		will not check to see if the struct itself has all zero
+		values, instead use a pointer or put nonzero on the struct's
+		keys that you care about. (Usage: nonzero)
 	
 	regexp
 		Only valid for string types, it will validator that the

--- a/builtins.go
+++ b/builtins.go
@@ -44,6 +44,8 @@ func nonzero(v interface{}, param string) error {
 		valid = st.Bool()
 	case reflect.Invalid:
 		valid = false // always invalid
+	case reflect.Struct:
+		valid = true // always valid since only nil pointers are empty
 	default:
 		return ErrUnsupported
 	}


### PR DESCRIPTION
Specifically allow struct's in nonzero and add tests for pointers
Restores backwards compatibility to before #38 

This addresses concerns that @svanharmelen brought up on 6dc26c29a0067df5a502b795afc66442b026a30f with a backwards compatibility break in #38. It looks like `nonzero` was only working on pointers before because when we converted the pointer to a struct in `Validate` we didn't actually run `nonzero` on the struct since we didn't support structs until #38. It was working by accident.

This new PR restores backwards compatibility allowing all structs to pass `nonzero` and I added a note to `nonzero` explaining that it does not check to see if the struct is in a zero state, only looks for `nil`. I also added a bunch more tests to make sure pointer handling doesn't break in the future.
