### PR TITLE
add len,min,max,regex... support for pointer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ A simple example would be.
 
 Builtin validators
 
-Here is the list of validators buildin in the package.
+Here is the list of validators buildin in the package. Validators buildin
+will check the element pointed to if the value to check is a pointer. 
+The `nil` pointer is treated as a valid value by validators buildin other
+than `nonzero`, so you should to use `nonzero` if you don't want to 
+accept a `nil` pointer.
 
 	len
 		For numeric numbers, max will simply make sure that the

--- a/builtins.go
+++ b/builtins.go
@@ -62,6 +62,12 @@ func nonzero(v interface{}, param string) error {
 func length(v interface{}, param string) error {
 	st := reflect.ValueOf(v)
 	valid := true
+	if st.Kind() == reflect.Ptr {
+		if st.IsNil() {
+			return nil
+		}
+		st = st.Elem()
+	}
 	switch st.Kind() {
 	case reflect.String:
 		p, err := asInt(param)
@@ -109,6 +115,12 @@ func length(v interface{}, param string) error {
 func min(v interface{}, param string) error {
 	st := reflect.ValueOf(v)
 	invalid := false
+	if st.Kind() == reflect.Ptr {
+		if st.IsNil() {
+			return nil
+		}
+		st = st.Elem()
+	}
 	switch st.Kind() {
 	case reflect.String:
 		p, err := asInt(param)
@@ -156,6 +168,12 @@ func min(v interface{}, param string) error {
 func max(v interface{}, param string) error {
 	st := reflect.ValueOf(v)
 	var invalid bool
+	if st.Kind() == reflect.Ptr {
+		if st.IsNil() {
+			return nil
+		}
+		st = st.Elem()
+	}
 	switch st.Kind() {
 	case reflect.String:
 		p, err := asInt(param)
@@ -201,7 +219,14 @@ func max(v interface{}, param string) error {
 func regex(v interface{}, param string) error {
 	s, ok := v.(string)
 	if !ok {
-		return ErrUnsupported
+		sptr, ok := v.(*string)
+		if !ok {
+			return ErrUnsupported
+		}
+		if sptr == nil {
+			return nil
+		}
+		s = *sptr
 	}
 
 	re, err := regexp.Compile(param)

--- a/validator_test.go
+++ b/validator_test.go
@@ -313,6 +313,20 @@ func (ms *MySuite) TestValidatePointerVar(c *C) {
 
 	err = validator.Validate(&test6{&test2{}})
 	c.Assert(err, IsNil)
+
+	type test7 struct {
+		A *string `validate:"min=6"`
+		B *int    `validate:"len=7"`
+		C *int    `validate:"min=12"`
+	}
+	s := "aaa"
+	b := 8
+	err = validator.Validate(&test7{&s, &b, nil})
+	errs, ok = err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs["A"], HasError, validator.ErrMin)
+	c.Assert(errs["B"], HasError, validator.ErrLen)
+	c.Assert(errs["C"], Not(HasError), validator.ErrMin)
 }
 
 func (ms *MySuite) TestValidateOmittedStructVar(c *C) {


### PR DESCRIPTION
In our project, we use struct contains pointer type variables to distinct between empty and nil value. But validator not supported pointer type couldn't satisfy this situation. So I implement len,min,max,regex... builtin validators for elem of pointer types.

Request to merge.
