### PR TITLE
Deep validate arrays, structs and maps

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -213,6 +213,11 @@ func (mv *Validator) Validate(v interface{}) error {
 	nfields := sv.NumField()
 	m := make(ErrorMap)
 	for i := 0; i < nfields; i++ {
+		fname := st.Field(i).Name
+		if !unicode.IsUpper(rune(fname[0])) {
+			continue
+		}
+
 		f := sv.Field(i)
 		// deal with pointers
 		for f.Kind() == reflect.Ptr && !f.IsNil() {
@@ -222,7 +227,6 @@ func (mv *Validator) Validate(v interface{}) error {
 		if tag == "-" {
 			continue
 		}
-		fname := st.Field(i).Name
 		var errs ErrorArray
 
 		if tag != "" {
@@ -236,9 +240,6 @@ func (mv *Validator) Validate(v interface{}) error {
 			}
 		}
 		if f.Kind() == reflect.Struct || f.Kind() == reflect.Interface {
-			if !unicode.IsUpper(rune(fname[0])) {
-				continue
-			}
 			e := mv.Validate(f.Interface())
 			if e, ok := e.(ErrorMap); ok && len(e) > 0 {
 				for j, k := range e {

--- a/validator.go
+++ b/validator.go
@@ -255,7 +255,7 @@ func (mv *Validator) Validate(v interface{}) error {
 
 func (mv *Validator) deepValidateCollection(f reflect.Value, fname string, m ErrorMap) {
 	switch f.Kind() {
-	case reflect.Struct, reflect.Interface:
+	case reflect.Struct, reflect.Interface, reflect.Ptr:
 		e := mv.Validate(f.Interface())
 		if e, ok := e.(ErrorMap); ok && len(e) > 0 {
 			for j, k := range e {

--- a/validator_test.go
+++ b/validator_test.go
@@ -344,6 +344,76 @@ func (ms *MySuite) TestUnknownTag(c *C) {
 	c.Assert(errs["A"], HasError, validator.ErrUnknownTag)
 }
 
+func (ms *MySuite) TestValidateStructWithSlice(c *C) {
+	type test2 struct {
+		Num    int    `validate:"max=2"`
+		String string `validate:"nonzero"`
+	}
+
+	type test struct {
+		Slices []test2 `validate:"len=1"`
+	}
+
+	t := test{
+		Slices: []test2{{
+			Num:    6,
+			String: "foo",
+		}},
+	}
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs["Slices[0].Num"], HasError, validator.ErrMax)
+	c.Assert(errs["Slices[0].String"], IsNil) // sanity check
+}
+
+func (ms *MySuite) TestValidateStructWithNestedSlice(c *C) {
+	type test2 struct {
+		Num int `validate:"max=2"`
+	}
+
+	type test struct {
+		Slices [][]test2
+	}
+
+	t := test{
+		Slices: [][]test2{{{Num: 6}}},
+	}
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs["Slices[0][0].Num"], HasError, validator.ErrMax)
+}
+
+func (ms *MySuite) TestValidateStructWithMap(c *C) {
+	type test2 struct {
+		Num int `validate:"max=2"`
+	}
+
+	type test struct {
+		Map          map[string]test2
+		StructKeyMap map[test2]test2
+	}
+
+	t := test{
+		Map: map[string]test2{
+			"hello": {Num: 6},
+		},
+		StructKeyMap: map[test2]test2{
+			{Num: 3}: {Num: 1},
+		},
+	}
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+
+	c.Assert(errs["Map[hello](value).Num"], HasError, validator.ErrMax)
+	c.Assert(errs["StructKeyMap[{Num:3}](key).Num"], HasError, validator.ErrMax)
+}
+
 func (ms *MySuite) TestUnsupported(c *C) {
 	type test struct {
 		A int     `validate:"regexp=a.*b"`


### PR DESCRIPTION
Basically a new version of #37.

It also adds support for validating map struct-values (and struct-keys, if people need to do that).