### PR TITLE
Replaced len() with utf8.RuneCountInString()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+  - 1.4
+  - 1.5
+script:
+  - go test -race -v -bench=.
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 go:
-  - 1.4
   - 1.5
+  - 1.6
+  - 1.7
+go_import_path: gopkg.in/validator.v2
 script:
   - go test -race -v -bench=.
 notifications:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Here is the list of validators buildin in the package.
 	nonzero
 		This validates that the value is not zero. The appropriate
 		zero value is given by the Go spec (e.g. for int it's 0, for
-		string it's "", for pointers is nil, etc.) Usage: nonzero
+		string it's "", for pointers is nil, etc.) For structs, it
+		will not check to see if the struct itself has all zero
+		values, instead use a pointer or put nonzero on the struct's
+		keys that you care about. (Usage: nonzero)
 	
 	regexp
 		Only valid for string types, it will validator that the

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Then it is possible to use the notzz validation tag. This will print
 		A string  `validate:"nonzero,notzz"`
 	}
 	t := T{"ZZ"}
-	if valid, errs := validator.Validate(t); !valid {
+	if errs := validator.Validate(t); errs != nil {
 		fmt.Printf("Field A error: %s\n", errs["A"][0])
 	}
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A simple example would be.
 	}
 
 	nur := NewUserRequest{Username: "something", Age: 20}
-	if valid, errs := validator.Validate(nur); !valid {
+	if errs := validator.Validate(nur); errs != nil {
 		// values not valid, deal with errors here
 	}
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ Installation
 
 Just use go get.
 
-	go get gopkg.in/validator.v2
+```bash
+go get gopkg.in/validator.v2
+```
 
 And then just import the package into your own code.
 
-	import (
-		"gopkg.in/validator.v2"
-	)
+```go
+import (
+	"gopkg.in/validator.v2"
+)
+```
 
 Usage
 =====
@@ -22,109 +26,122 @@ Usage
 Please see http://godoc.org/gopkg.in/validator.v2 for detailed usage docs.
 A simple example would be.
 
-	type NewUserRequest struct {
-		Username string `validate:"min=3,max=40,regexp=^[a-zA-Z]*$"`
-		Name string     `validate:"nonzero"`
-		Age int         `validate:"min=21"`
-		Password string `validate:"min=8"`
-	}
+```go
+type NewUserRequest struct {
+	Username string `validate:"min=3,max=40,regexp=^[a-zA-Z]*$"`
+	Name string     `validate:"nonzero"`
+	Age int         `validate:"min=21"`
+	Password string `validate:"min=8"`
+}
 
-	nur := NewUserRequest{Username: "something", Age: 20}
-	if errs := validator.Validate(nur); errs != nil {
-		// values not valid, deal with errors here
-	}
-
+nur := NewUserRequest{Username: "something", Age: 20}
+if errs := validator.Validate(nur); errs != nil {
+	// values not valid, deal with errors here
+}
+```
 
 Builtin validators
 
 Here is the list of validators buildin in the package.
 
-	len
-		For numeric numbers, max will simply make sure that the
-		value is equal to the parameter given. For strings, it
-		checks that the string length is exactly that number of
-		characters. For slices,	arrays, and maps, validates the
-		number of items. (Usage: len=10)
-	
-	max
-		For numeric numbers, max will simply make sure that the
-		value is lesser or equal to the parameter given. For strings,
-		it checks that the string length is at most that number of
-		characters. For slices,	arrays, and maps, validates the
-		number of items. (Usage: max=10)
-	
-	min
-		For numeric numbers, min will simply make sure that the value
-		is greater or equal to the parameter given. For strings, it
-		checks that the string length is at least that number of
-		characters. For slices, arrays, and maps, validates the
-		number of items. (Usage: min=10)
-	
-	nonzero
-		This validates that the value is not zero. The appropriate
-		zero value is given by the Go spec (e.g. for int it's 0, for
-		string it's "", for pointers is nil, etc.) For structs, it
-		will not check to see if the struct itself has all zero
-		values, instead use a pointer or put nonzero on the struct's
-		keys that you care about. (Usage: nonzero)
-	
-	regexp
-		Only valid for string types, it will validator that the
-		value matches the regular expression provided as parameter.
-		(Usage: regexp=^a.*b$)
+```
+len
+	For numeric numbers, max will simply make sure that the
+	value is equal to the parameter given. For strings, it
+	checks that the string length is exactly that number of
+	characters. For slices,	arrays, and maps, validates the
+	number of items. (Usage: len=10)
+
+max
+	For numeric numbers, max will simply make sure that the
+	value is lesser or equal to the parameter given. For strings,
+	it checks that the string length is at most that number of
+	characters. For slices,	arrays, and maps, validates the
+	number of items. (Usage: max=10)
+
+min
+	For numeric numbers, min will simply make sure that the value
+	is greater or equal to the parameter given. For strings, it
+	checks that the string length is at least that number of
+	characters. For slices, arrays, and maps, validates the
+	number of items. (Usage: min=10)
+
+nonzero
+	This validates that the value is not zero. The appropriate
+	zero value is given by the Go spec (e.g. for int it's 0, for
+	string it's "", for pointers is nil, etc.) For structs, it
+	will not check to see if the struct itself has all zero
+	values, instead use a pointer or put nonzero on the struct's
+	keys that you care about. (Usage: nonzero)
+
+regexp
+	Only valid for string types, it will validator that the
+	value matches the regular expression provided as parameter.
+	(Usage: regexp=^a.*b$)
+```
 
 Custom validators
 
 It is possible to define custom validators by using SetValidationFunc.
 First, one needs to create a validation function.
 
-	// Very simple validator
-	func notZZ(v interface{}, param string) error {
-		st := reflect.ValueOf(v)
-		if st.Kind() != reflect.String {
-			return errors.New("notZZ only validates strings")
-		}
-		if st.String() == "ZZ" {
-			return errors.New("value cannot be ZZ")
-		}
-		return nil
+```go
+// Very simple validator
+func notZZ(v interface{}, param string) error {
+	st := reflect.ValueOf(v)
+	if st.Kind() != reflect.String {
+		return errors.New("notZZ only validates strings")
 	}
+	if st.String() == "ZZ" {
+		return errors.New("value cannot be ZZ")
+	}
+	return nil
+}
+```
 
 Then one needs to add it to the list of validators and give it a "tag"
 name.
 
-	validator.SetValidationFunc("notzz", notZZ)
+```go
+validator.SetValidationFunc("notzz", notZZ)
+```
 
 Then it is possible to use the notzz validation tag. This will print
 "Field A error: value cannot be ZZ"
 
-	type T struct {
-		A string  `validate:"nonzero,notzz"`
-	}
-	t := T{"ZZ"}
-	if errs := validator.Validate(t); errs != nil {
-		fmt.Printf("Field A error: %s\n", errs["A"][0])
-	}
+```go
+type T struct {
+	A string  `validate:"nonzero,notzz"`
+}
+t := T{"ZZ"}
+if errs := validator.Validate(t); errs != nil {
+	fmt.Printf("Field A error: %s\n", errs["A"][0])
+}
+```
 
 You can also have multiple sets of validator rules with SetTag().
 
-	type T struct {
-		A int `foo:"nonzero" bar:"min=10"`
-	}
-	t := T{5}
-	SetTag("foo")
-	validator.Validate(t) // valid as it's nonzero
-	SetTag("bar")
-	validator.Validate(t) // invalid as it's less than 10
+```go
+type T struct {
+	A int `foo:"nonzero" bar:"min=10"`
+}
+t := T{5}
+SetTag("foo")
+validator.Validate(t) // valid as it's nonzero
+SetTag("bar")
+validator.Validate(t) // invalid as it's less than 10
+```
 
 SetTag is probably better used with multiple validators.
 
-	fooValidator := validator.NewValidator()
-	fooValidator.SetTag("foo")
-	barValidator := validator.NewValidator()
-	barValidator.SetTag("bar")
-	fooValidator.Validate(t)
-	barValidator.Validate(t)
+```go
+fooValidator := validator.NewValidator()
+fooValidator.SetTag("foo")
+barValidator := validator.NewValidator()
+barValidator.SetTag("bar")
+fooValidator.Validate(t)
+barValidator.Validate(t)
+```
 
 This keeps the default validator's tag clean. Again, please refer to
 godocs for a lot of more examples and different uses.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ A simple example would be.
 
 Builtin validators
 
-Here is the list of validators buildin in the package.
+Here is the list of validators buildin in the package. Validators buildin
+will check the element pointed to if the value to check is a pointer. 
+The `nil` pointer is treated as a valid value by validators buildin other
+than `nonzero`, so you should to use `nonzero` if you don't want to 
+accept a `nil` pointer.
 
 	len
 		For numeric numbers, max will simply make sure that the

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Please see http://godoc.org/gopkg.in/validator.v1 for detailed usage docs.
 A simple example would be.
 
 	type NewUserRequest struct {
-		Username string `validator:"min=3,max=40,regexp=^[a-zA-Z]$"`
-		Name string     `validator:"nonzero"`
-		Age int         `validator:"min=21"`
-		Password string `validator:"min=8"`
+		Username string `validate:"min=3,max=40,regexp=^[a-zA-Z]$"`
+		Name string     `validate:"nonzero"`
+		Age int         `validate:"min=21"`
+		Password string `validate:"min=8"`
 	}
 
 	nur := NewUserRequest{Username: "something", Age: 20}
@@ -96,7 +96,7 @@ Then it is possible to use the notzz validation tag. This will print
 "Field A error: value cannot be ZZ"
 
 	type T struct {
-		A string  `validator:"nonzero,notzz"`
+		A string  `validate:"nonzero,notzz"`
 	}
 	t := T{"ZZ"}
 	if valid, errs := validator.Validate(t); !valid {

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ Installation
 
 Just use go get.
 
-	go get gopkg.in/validator.v1
+	go get gopkg.in/validator.v2
 
 And then just import the package into your own code.
 
 	import (
-		"gopkg.in/validator.v1"
+		"gopkg.in/validator.v2"
 	)
 
 Usage
 =====
 
-Please see http://godoc.org/gopkg.in/validator.v1 for detailed usage docs.
+Please see http://godoc.org/gopkg.in/validator.v2 for detailed usage docs.
 A simple example would be.
 
 	type NewUserRequest struct {
@@ -132,7 +132,7 @@ Pull requests policy
 tl;dr. Contributions are welcome.
 
 The repository is organized in version branches. Pull requests to, say, the
-`v1` branch that break API compatibility will not be accepted. It is okay to
+`v2` branch that break API compatibility will not be accepted. It is okay to
 break the API in master, *not in the branches*.
 
 As for validation functions, the preference is to keep the main code simple

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ accept a `nil` pointer.
 
 ```
 len
-	For numeric numbers, max will simply make sure that the
+	For numeric numbers, len will simply make sure that the
 	value is equal to the parameter given. For strings, it
 	checks that the string length is exactly that number of
 	characters. For slices,	arrays, and maps, validates the

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please see http://godoc.org/gopkg.in/validator.v2 for detailed usage docs.
 A simple example would be.
 
 	type NewUserRequest struct {
-		Username string `validate:"min=3,max=40,regexp=^[a-zA-Z]$"`
+		Username string `validate:"min=3,max=40,regexp=^[a-zA-Z]*$"`
 		Name string     `validate:"nonzero"`
 		Age int         `validate:"min=21"`
 		Password string `validate:"min=8"`

--- a/builtins.go
+++ b/builtins.go
@@ -62,6 +62,12 @@ func nonzero(v interface{}, param string) error {
 func length(v interface{}, param string) error {
 	st := reflect.ValueOf(v)
 	valid := true
+	if st.Kind() == reflect.Ptr {
+		if st.IsNil() {
+			return nil
+		}
+		st = st.Elem()
+	}
 	switch st.Kind() {
 	case reflect.String:
 		p, err := asInt(param)
@@ -109,6 +115,12 @@ func length(v interface{}, param string) error {
 func min(v interface{}, param string) error {
 	st := reflect.ValueOf(v)
 	invalid := false
+	if st.Kind() == reflect.Ptr {
+		if st.IsNil() {
+			return nil
+		}
+		st = st.Elem()
+	}
 	switch st.Kind() {
 	case reflect.String:
 		p, err := asInt(param)
@@ -156,6 +168,12 @@ func min(v interface{}, param string) error {
 func max(v interface{}, param string) error {
 	st := reflect.ValueOf(v)
 	var invalid bool
+	if st.Kind() == reflect.Ptr {
+		if st.IsNil() {
+			return nil
+		}
+		st = st.Elem()
+	}
 	switch st.Kind() {
 	case reflect.String:
 		p, err := asInt(param)
@@ -201,7 +219,14 @@ func max(v interface{}, param string) error {
 func regex(v interface{}, param string) error {
 	s, ok := v.(string)
 	if !ok {
-		return ErrUnsupported
+		sptr, ok := v.(*string)
+		if !ok {
+			return ErrUnsupported
+		}
+		if sptr == nil {
+			return nil
+		}
+		s = *sptr
 	}
 
 	re, err := regexp.Compile(param)

--- a/builtins.go
+++ b/builtins.go
@@ -44,6 +44,8 @@ func nonzero(v interface{}, param string) error {
 		valid = st.Bool()
 	case reflect.Invalid:
 		valid = false // always invalid
+	case reflect.Struct:
+		valid = true // always valid since only nil pointers are empty
 	default:
 		return ErrUnsupported
 	}

--- a/builtins.go
+++ b/builtins.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"unicode/utf8"
 )
 
 // nonzero tests whether a variable value non-zero
@@ -29,7 +30,7 @@ func nonzero(v interface{}, param string) error {
 	valid := true
 	switch st.Kind() {
 	case reflect.String:
-		valid = len(st.String()) != 0
+		valid = utf8.RuneCountInString(st.String()) != 0
 	case reflect.Ptr, reflect.Interface:
 		valid = !st.IsNil()
 	case reflect.Slice, reflect.Map, reflect.Array:
@@ -74,7 +75,7 @@ func length(v interface{}, param string) error {
 		if err != nil {
 			return ErrBadParameter
 		}
-		valid = int64(len(st.String())) == p
+		valid = int64(utf8.RuneCountInString(st.String())) == p
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p, err := asInt(param)
 		if err != nil {
@@ -127,7 +128,7 @@ func min(v interface{}, param string) error {
 		if err != nil {
 			return ErrBadParameter
 		}
-		invalid = int64(len(st.String())) < p
+		invalid = int64(utf8.RuneCountInString(st.String())) < p
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p, err := asInt(param)
 		if err != nil {
@@ -180,7 +181,7 @@ func max(v interface{}, param string) error {
 		if err != nil {
 			return ErrBadParameter
 		}
-		invalid = int64(len(st.String())) > p
+		invalid = int64(utf8.RuneCountInString(st.String())) > p
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p, err := asInt(param)
 		if err != nil {

--- a/doc.go
+++ b/doc.go
@@ -36,7 +36,7 @@ You get the idea. Package validator allows one to define valid values as
 struct tags when defining a new struct type.
 
 	type NewUserRequest struct {
-		Username string `validate:"min=3,max=40,regexp=^[a-zA-Z]$"`
+		Username string `validate:"min=3,max=40,regexp=^[a-zA-Z]*$"`
 		Name string     `validate:"nonzero"`
 		Age int         `validate:"min=18"`
 		Password string `validate:"min=8"`

--- a/doc.go
+++ b/doc.go
@@ -85,7 +85,7 @@ Note that there are no tests to prevent conflicting validator parameters. For
 instance, these fields will never be valid.
 
 	...
-	A int     `validate:"max=0,nonzero"`
+	A int     `validate:"max=0,min=1"`
 	B string  `validate:"len=10,regexp=^$"
 	...
 
@@ -98,7 +98,7 @@ First, one needs to create a validation function.
 	func notZZ(v interface{}, param string) error {
 		st := reflect.ValueOf(v)
 		if st.Kind() != reflect.String {
-			return errors.New("notZZ only validates strings")
+			return validate.ErrUnsupported
 		}
 		if st.String() == "ZZ" {
 			return errors.New("value cannot be ZZ")
@@ -127,7 +127,7 @@ To use parameters, it is very similar.
 	func notSomething(v interface{}, param string) error {
 		st := reflect.ValueOf(v)
 		if st.Kind() != reflect.String {
-			return errors.New("notSomething only validates strings")
+			return validate.ErrUnsupported
 		}
 		if st.String() == param {
 			return errors.New("value cannot be " + param)
@@ -155,7 +155,8 @@ And you can delete a validation function by setting it to nil.
 	validate.SetValidationFunc("notzz", nil)
 	validate.SetValidationFunc("nonzero", nil)
 
-Using a non-existing validation func in a field tag will panic.
+Using a non-existing validation func in a field tag will always return
+false and with error validate.ErrUnknownTag.
 
 Finally, package validator also provides a helper function that can be used
 to validate simple variables/values.

--- a/doc.go
+++ b/doc.go
@@ -53,8 +53,8 @@ Builtin validator functions
 
 Here is the list of validator functions builtin in the package.
 
-	max
-		For numeric numbers, max will simply make sure that the value is
+	len
+		For numeric numbers, len will simply make sure that the value is
 		equal to the parameter given. For strings, it checks that
 		the string length is exactly that number of characters. For slices,
 		arrays, and maps, validates the number of items. (Usage: len=10)

--- a/doc.go
+++ b/doc.go
@@ -45,7 +45,7 @@ struct tags when defining a new struct type.
 Then validating a variable of type NewUserRequest becomes trivial.
 
 	nur := NewUserRequest{Username: "something", ...}
-	if valid, _ := validator.Validate(nur); valid {
+	if errs := validator.Validate(nur); errs != nil {
 		// do something
 	}
 
@@ -117,7 +117,7 @@ Then it is possible to use the notzz validation tag. This will print
 		A string  `validate:"nonzero,notzz"`
 	}
 	t := T{"ZZ"}
-	if valid, errs := validator.Validate(t); !valid {
+	if errs := validator.Validate(t); errs != nil {
 		fmt.Printf("Field A error: %s\n", errs["A"][0])
 	}
 
@@ -142,7 +142,7 @@ And then the code below should print "Field A error: value cannot be ABC".
 		A string  `validate:"notsomething=ABC"`
 	}
 	t := T{"ABC"}
-	if valid, errs := validator.Validate(t); !valid {
+	if errs := validator.Validate(t); errs != nil {
 		fmt.Printf("Field A error: %s\n", errs["A"][0])
 	}
 
@@ -161,14 +161,14 @@ false and with error validate.ErrUnknownTag.
 Finally, package validator also provides a helper function that can be used
 to validate simple variables/values.
 
-    // valid: true, errs: []
-	valid, errs = validator.Valid(42, "min=10, max=50")
+    	// errs: nil
+	errs = validator.Valid(42, "min=10, max=50")
 
-	// valid: false, errs: [validate.ErrZeroValue]
-	valid, errs = validator.Valid(nil, "nonzero")
+	// errs: [validate.ErrZeroValue]
+	errs = validator.Valid(nil, "nonzero")
 
-	// valid: false, errs: [validate.ErrMin,validate.ErrMax]
-	valid, errs = validator.Valid("hi", "nonzero,min=3,max=2")
+	// errs: [validate.ErrMin,validate.ErrMax]
+	errs = validator.Valid("hi", "nonzero,min=3,max=2")
 
 Custom tag name
 
@@ -238,7 +238,7 @@ You might use two different validators.
 	func CreateUserHandler(w http.ResponseWriter, r *http.Request) {
 		var u User
 		json.NewDecoder(r.Body).Decode(&user)
-		if valid, _ := creationValidator.Validate(user); !valid {
+		if errs := creationValidator.Validate(user); errs != nil {
 			// the request did not include all of the User
 			// struct fields, so send a http.StatusBadRequest
 			// back or something
@@ -249,7 +249,7 @@ You might use two different validators.
 	func SetNewUserPasswordHandler(w http.ResponseWriter, r *http.Request) {
 		var u User
 		json.NewDecoder(r.Body).Decode(&user)
-		if valid, _ := chgPwValidator.Validate(user); !valid {
+		if errs := chgPwValidator.Validate(user); errs != nil {
 			// the request did not Username and Password,
 			// so send a http.StatusBadRequest
 			// back or something

--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -50,10 +50,11 @@ func ExampleValidate() {
 	ve.Address.City = "Some City" // valid
 	ve.Address.Street = ""        // invalid
 
-	valid, errs := validator.Validate(ve)
-	if valid {
+	err := validator.Validate(ve)
+	if err == nil {
 		fmt.Println("Values are valid.")
 	} else {
+		errs := err.(validator.ErrorMap)
 		// See if Address was empty
 		if errs["Address.Street"][0] == validator.ErrZeroValue {
 			fmt.Println("Street cannot be empty.")
@@ -102,15 +103,16 @@ func ExampleSetTag() {
 	t := T{5}
 	v := validator.NewValidator()
 	v.SetTag("foo")
-	valid, errs := v.Validate(t)
-	fmt.Printf("foo --> valid: %v, errs: %v\n", valid, errs)
+	err := v.Validate(t)
+	fmt.Printf("foo --> valid: %v, errs: %v\n", err == nil, err)
 	v.SetTag("bar")
-	valid, errs = v.Validate(t)
-	fmt.Printf("bar --> valid: %v, errs: %v\n", valid, errs)
+	err = v.Validate(t)
+	errs := err.(validator.ErrorMap)
+	fmt.Printf("bar --> valid: %v, errs: %v\n", err == nil, errs)
 
 	// Output:
-	// foo --> valid: true, errs: map[]
-	// bar --> valid: false, errs: map[A:[less than min]]
+	// foo --> valid: true, errs: <nil>
+	// bar --> valid: false, errs: A: less than min
 }
 
 // This example shows you how to change the tag name
@@ -119,12 +121,12 @@ func ExampleWithTag() {
 		A int `foo:"nonzero" bar:"min=10"`
 	}
 	t := T{5}
-	valid, errs := validator.WithTag("foo").Validate(t)
-	fmt.Printf("foo --> valid: %v, errs: %v\n", valid, errs)
-	valid, errs = validator.WithTag("bar").Validate(t)
-	fmt.Printf("bar --> valid: %v, errs: %v\n", valid, errs)
+	err := validator.WithTag("foo").Validate(t)
+	fmt.Printf("foo --> valid: %v, errs: %v\n", err == nil, err)
+	err = validator.WithTag("bar").Validate(t)
+	fmt.Printf("bar --> valid: %v, errs: %v\n", err == nil, err)
 
 	// Output:
-	// foo --> valid: true, errs: map[]
-	// bar --> valid: false, errs: map[A:[less than min]]
+	// foo --> valid: true, errs: <nil>
+	// bar --> valid: false, errs: A: less than min
 }

--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -70,27 +70,27 @@ func ExampleValidate() {
 	// Output:
 	// Street cannot be empty.
 	// Invalid due to fields:
-	//	 - Age ([less than min])
-	//	 - Email ([regular expression mismatch])
-	//	 - Address.Street ([zero value])
+	//	 - Age (less than min)
+	//	 - Email (regular expression mismatch)
+	//	 - Address.Street (zero value)
 }
 
 // This example shows how to use the Valid helper
 // function to validator any number of values
 func ExampleValid() {
-	valid, errs := validator.Valid(42, "min=10,max=100,nonzero")
-	fmt.Printf("42: valid=%v, errs=%v\n", valid, errs)
+	err := validator.Valid(42, "min=10,max=100,nonzero")
+	fmt.Printf("42: valid=%v, errs=%v\n", err == nil, err)
 
 	var ptr *int
-	if valid, _ := validator.Valid(ptr, "nonzero"); !valid {
+	if err := validator.Valid(ptr, "nonzero"); err != nil {
 		fmt.Println("ptr: Invalid nil pointer.")
 	}
 
-	valid, _ = validator.Valid("ABBA", "regexp=[ABC]*")
-	fmt.Printf("ABBA: valid=%v\n", valid)
+	err = validator.Valid("ABBA", "regexp=[ABC]*")
+	fmt.Printf("ABBA: valid=%v\n", err == nil)
 
 	// Output:
-	// 42: valid=true, errs=[]
+	// 42: valid=true, errs=<nil>
 	// ptr: Invalid nil pointer.
 	// ABBA: valid=true
 }

--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -70,7 +70,7 @@ func ExampleValidate() {
 	// Street cannot be empty.
 	// Invalid due to fields:
 	//	 - Age ([less than min])
-	//	 - Email ([regexp does not match])
+	//	 - Email ([regular expression mismatch])
 	//	 - Address.Street ([zero value])
 }
 

--- a/examplevalidate_test.go
+++ b/examplevalidate_test.go
@@ -18,6 +18,7 @@ package validator_test
 
 import (
 	"fmt"
+	"sort"
 
 	"gopkg.in/validator.v1"
 )
@@ -61,17 +62,29 @@ func ExampleValidate() {
 
 		// Iterate through the list of fields and respective errors
 		fmt.Println("Invalid due to fields:")
+
+		// Here we have to sort the arrays to ensure map ordering does not
+		// fail our example, typically it's ok to just range through the err
+		// list when order is not important.
+		var errOuts []string
 		for f, e := range errs {
-			fmt.Printf("\t - %s (%v)\n", f, e)
+			errOuts = append(errOuts, fmt.Sprintf("\t - %s (%v)\n", f, e))
+		}
+
+		// Again this part is extraneous and you should not need this in real
+		// code.
+		sort.Strings(errOuts)
+		for _, str := range errOuts {
+			fmt.Print(str)
 		}
 	}
 
 	// Output:
 	// Street cannot be empty.
 	// Invalid due to fields:
+	//	 - Address.Street ([zero value])
 	//	 - Age ([less than min])
 	//	 - Email ([regular expression mismatch])
-	//	 - Address.Street ([zero value])
 }
 
 // This example shows how to use the Valid helper

--- a/validator.go
+++ b/validator.go
@@ -158,9 +158,13 @@ func (mv *Validator) WithTag(tag string) *Validator {
 
 // Copy a validator
 func (mv *Validator) copy() *Validator {
+	newFuncs := map[string]ValidationFunc{}
+	for k, f := range mv.validationFuncs {
+		newFuncs[k] = f
+	}
 	return &Validator{
 		tagName:         mv.tagName,
-		validationFuncs: mv.validationFuncs,
+		validationFuncs: newFuncs,
 	}
 }
 

--- a/validator.go
+++ b/validator.go
@@ -22,34 +22,52 @@ import (
 	"strings"
 )
 
+// TextErr is an error that also implements the TextMarshaller interface for
+// serializing out to various plain text encodings. Packages creating their
+// own custom errors should use TextErr if they're intending to use serializing
+// formats like json, msgpack etc.
+type TextErr struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (t TextErr) Error() string {
+	return t.Err.Error()
+}
+
+// MarshalText implements the TextMarshaller
+func (t TextErr) MarshalText() ([]byte, error) {
+	return []byte(t.Err.Error()), nil
+}
+
 var (
 	// ErrZeroValue is the error returned when variable has zero valud
 	// and nonzero was specified
-	ErrZeroValue = errors.New("zero value")
+	ErrZeroValue = TextErr{errors.New("zero value")}
 	// ErrMin is the error returned when variable is less than mininum
 	// value specified
-	ErrMin = errors.New("less than min")
+	ErrMin = TextErr{errors.New("less than min")}
 	// ErrMax is the error returned when variable is more than
 	// maximum specified
-	ErrMax = errors.New("greater than max")
+	ErrMax = TextErr{errors.New("greater than max")}
 	// ErrLen is the error returned when length is not equal to
 	// param specified
-	ErrLen = errors.New("invalid length")
+	ErrLen = TextErr{errors.New("invalid length")}
 	// ErrRegexp is the error returned when the value does not
 	// match the provided regular expression parameter
-	ErrRegexp = errors.New("regular expression mismatch")
+	ErrRegexp = TextErr{errors.New("regular expression mismatch")}
 	// ErrUnsupported is the error error returned when a validation rule
 	// is used with an unsupported variable type
-	ErrUnsupported = errors.New("unsupported type")
+	ErrUnsupported = TextErr{errors.New("unsupported type")}
 	// ErrBadParameter is the error returned when an invalid parameter
 	// is provided to a validation rule (e.g. a string where an int was
 	// expected (max=foo,len=bar) or missing a parameter when one is required (len=))
-	ErrBadParameter = errors.New("bad parameter")
+	ErrBadParameter = TextErr{errors.New("bad parameter")}
 	// ErrUnknownTag is the error returned when an unknown tag is found
-	ErrUnknownTag = errors.New("unknown tag")
+	ErrUnknownTag = TextErr{errors.New("unknown tag")}
 	// ErrInvalid is the error returned when variable is invalid
 	// (normally a nil pointer)
-	ErrInvalid = errors.New("invalid value")
+	ErrInvalid = TextErr{errors.New("invalid value")}
 )
 
 // ValidationFunc is a function that receives the value of a

--- a/validator.go
+++ b/validator.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"unicode"
 )
@@ -308,11 +309,27 @@ type tag struct {
 	Param string         // parameter to send to the validation function
 }
 
+// separate by no escaped commas
+var sepPattern *regexp.Regexp = regexp.MustCompile(`((?:^|[^\\])(?:\\\\)*),`)
+
+func splitUnescapedComma(str string) []string {
+	ret := []string{}
+	indexes := sepPattern.FindAllStringIndex(str, -1)
+	last := 0
+	for _, is := range indexes {
+		ret = append(ret, str[last:is[1]-1])
+		last = is[1]
+	}
+	ret = append(ret, str[last:])
+	return ret
+}
+
 // parseTags parses all individual tags found within a struct tag.
 func (mv *Validator) parseTags(t string) ([]tag, error) {
-	tl := strings.Split(t, ",")
+	tl := splitUnescapedComma(t)
 	tags := make([]tag, 0, len(tl))
 	for _, i := range tl {
+		i = strings.Replace(i, `\,`, ",", -1)
 		tg := tag{}
 		v := strings.SplitN(i, "=", 2)
 		tg.Name = strings.Trim(v[0], " ")

--- a/validator.go
+++ b/validator.go
@@ -213,6 +213,11 @@ func (mv *Validator) Validate(v interface{}) error {
 	nfields := sv.NumField()
 	m := make(ErrorMap)
 	for i := 0; i < nfields; i++ {
+		fname := st.Field(i).Name
+		if !unicode.IsUpper(rune(fname[0])) {
+			continue
+		}
+
 		f := sv.Field(i)
 		// deal with pointers
 		for f.Kind() == reflect.Ptr && !f.IsNil() {
@@ -222,7 +227,6 @@ func (mv *Validator) Validate(v interface{}) error {
 		if tag == "-" {
 			continue
 		}
-		fname := st.Field(i).Name
 		var errs ErrorArray
 
 		if tag != "" {
@@ -236,9 +240,6 @@ func (mv *Validator) Validate(v interface{}) error {
 			}
 		}
 		if f.Kind() == reflect.Struct || f.Kind() == reflect.Interface {
-			if !unicode.IsUpper(rune(fname[0])) {
-				continue
-			}
 			e := mv.Validate(f.Interface())
 			if e, ok := e.(ErrorMap); ok && len(e) > 0 {
 				for j, k := range e {

--- a/validator.go
+++ b/validator.go
@@ -179,7 +179,12 @@ func (mv *Validator) Validate(v interface{}) (bool, map[string][]error) {
 		if tag == "" && f.Kind() != reflect.Struct {
 			continue
 		}
-		fname := st.Field(i).Name
+		var fieldInfo = st.Field(i)
+		if len(fieldInfo.PkgPath) != 0 { // unexported field
+			continue
+		}
+		fname := fieldInfo.Name
+
 		var errs []error
 		switch f.Kind() {
 		case reflect.Struct:

--- a/validator.go
+++ b/validator.go
@@ -194,6 +194,9 @@ func (mv *Validator) Validate(v interface{}) (bool, map[string][]error) {
 
 			}
 		}
+		if tag == "-" {
+			continue
+		}
 		if tag == "" && f.Kind() != reflect.Struct {
 			continue
 		}

--- a/validator.go
+++ b/validator.go
@@ -202,7 +202,7 @@ func (mv *Validator) Validate(v interface{}) error {
 	if sv.Kind() == reflect.Ptr && !sv.IsNil() {
 		return mv.Validate(sv.Elem().Interface())
 	}
-	if sv.Kind() != reflect.Struct {
+	if sv.Kind() != reflect.Struct && sv.Kind() != reflect.Interface {
 		return ErrUnsupported
 	}
 
@@ -231,7 +231,7 @@ func (mv *Validator) Validate(v interface{}) error {
 				}
 			}
 		}
-		if f.Kind() == reflect.Struct {
+		if f.Kind() == reflect.Struct || f.Kind() == reflect.Interface {
 			if !unicode.IsUpper(rune(fname[0])) {
 				continue
 			}

--- a/validator.go
+++ b/validator.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"unicode"
 )
 
 // TextErr is an error that also implements the TextMarshaller interface for
@@ -230,6 +231,9 @@ func (mv *Validator) Validate(v interface{}) error {
 		var errs ErrorArray
 		switch f.Kind() {
 		case reflect.Struct:
+			if !unicode.IsUpper(rune(fname[0])) {
+				continue
+			}
 			e := mv.Validate(f.Interface())
 			if e, ok := e.(ErrorMap); ok && len(e) > 0 {
 				for j, k := range e {

--- a/validator.go
+++ b/validator.go
@@ -255,7 +255,7 @@ func (mv *Validator) Validate(v interface{}) error {
 
 func (mv *Validator) deepValidateCollection(f reflect.Value, fname string, m ErrorMap) {
 	switch f.Kind() {
-	case reflect.Struct, reflect.Interface:
+	case reflect.Struct, reflect.Interface, reflect.Ptr:
 		e := mv.Validate(f.Interface())
 		if e, ok := e.(ErrorMap); ok && len(e) > 0 {
 			for j, k := range e {

--- a/validator_test.go
+++ b/validator_test.go
@@ -181,14 +181,18 @@ func (ms *MySuite) TestValidateStructVar(c *C) {
 
 func (ms *MySuite) TestValidateOmittedStructVar(c *C) {
 	type test2 struct {
-		B int `validate:min=1`
+		B int `validate:"min=1"`
 	}
 	type test1 struct {
 		A test2 `validate:"-"`
 	}
 
 	t := test1{}
-	valid, errs := validator.Validate(t)
+	valid, err := validator.Validate(t)
+	c.Assert(valid, Equals, true)
+	c.Assert(err, HasLen, 0)
+
+	valid, errs := validator.Valid(test2{}, "-")
 	c.Assert(valid, Equals, true)
 	c.Assert(errs, HasLen, 0)
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -36,6 +36,18 @@ type Simple struct {
 	A int `validate:"min=10"`
 }
 
+type I interface {
+	Foo() string
+}
+
+type Impl struct {
+	F string `validate:"len=3"`
+}
+
+func (this *Impl) Foo() string {
+	return this.F
+}
+
 type TestStruct struct {
 	A   int    `validate:"nonzero"`
 	B   string `validate:"len=8,min=6,max=4"`
@@ -46,6 +58,7 @@ type TestStruct struct {
 		D *string `validate:"nonzero"`
 	}
 	D *Simple `validate:"nonzero"`
+	E I       `validate:nonzero`
 }
 
 func (ms *MySuite) TestValidate(c *C) {
@@ -57,6 +70,7 @@ func (ms *MySuite) TestValidate(c *C) {
 	t.Sub.B = ""
 	t.Sub.C = 0.0
 	t.D = &Simple{10}
+	t.E = &Impl{"hello"}
 
 	err := validator.Validate(t)
 	c.Assert(err, NotNil)
@@ -71,6 +85,7 @@ func (ms *MySuite) TestValidate(c *C) {
 	c.Assert(errs["Sub.B"], HasLen, 0)
 	c.Assert(errs["Sub.C"], HasLen, 2)
 	c.Assert(errs["Sub.D"], HasError, validator.ErrZeroValue)
+	c.Assert(errs["E.F"], HasError, validator.ErrLen)
 }
 
 func (ms *MySuite) TestValidSlice(c *C) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -344,6 +344,76 @@ func (ms *MySuite) TestUnknownTag(c *C) {
 	c.Assert(errs["A"], HasError, validator.ErrUnknownTag)
 }
 
+func (ms *MySuite) TestValidateStructWithSlice(c *C) {
+	type test2 struct {
+		Num    int    `validate:"max=2"`
+		String string `validate:"nonzero"`
+	}
+
+	type test struct {
+		Slices []test2 `validate:"len=1"`
+	}
+
+	t := test{
+		Slices: []test2{{
+			Num:    6,
+			String: "foo",
+		}},
+	}
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs["Slices[0].Num"], HasError, validator.ErrMax)
+	c.Assert(errs["Slices[0].String"], IsNil) // sanity check
+}
+
+func (ms *MySuite) TestValidateStructWithNestedSlice(c *C) {
+	type test2 struct {
+		Num int `validate:"max=2"`
+	}
+
+	type test struct {
+		Slices [][]test2
+	}
+
+	t := test{
+		Slices: [][]test2{{{Num: 6}}},
+	}
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs["Slices[0][0].Num"], HasError, validator.ErrMax)
+}
+
+func (ms *MySuite) TestValidateStructWithMap(c *C) {
+	type test2 struct {
+		Num int `validate:"max=2"`
+	}
+
+	type test struct {
+		Map          map[string]test2
+		StructKeyMap map[test2]test2
+	}
+
+	t := test{
+		Map: map[string]test2{
+			"hello": {Num: 6},
+		},
+		StructKeyMap: map[test2]test2{
+			{Num: 3}: {Num: 1},
+		},
+	}
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+
+	c.Assert(errs["Map[hello](value).Num"], HasError, validator.ErrMax)
+	c.Assert(errs["StructKeyMap[{Num:3}](key).Num"], HasError, validator.ErrMax)
+}
+
 func (ms *MySuite) TestUnsupported(c *C) {
 	type test struct {
 		A int     `validate:"regexp=a.*b"`

--- a/validator_test.go
+++ b/validator_test.go
@@ -397,6 +397,22 @@ func (ms *MySuite) TestCopy(c *C) {
 	c.Assert(errs["A"], HasError, validator.ErrUnknownTag)
 }
 
+func (ms *MySuite) TestTagEscape(c *C) {
+	type test struct {
+		A string `validate:"min=0,regexp=^a{3\\,10}"`
+	}
+	t := test{"aaaa"}
+	err := validator.Validate(t)
+	c.Assert(err, IsNil)
+
+	t2 := test{"aa"}
+	err = validator.Validate(t2)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs["A"], HasError, validator.ErrRegexp)
+}
+
 type hasErrorChecker struct {
 	*CheckerInfo
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -17,8 +17,9 @@
 package validator_test
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 
 	"gopkg.in/validator.v1"
 )
@@ -57,8 +58,11 @@ func (ms *MySuite) TestValidate(c *C) {
 	t.Sub.C = 0.0
 	t.D = &Simple{10}
 
-	valid, errs := validator.Validate(t)
-	c.Assert(valid, Equals, false, Commentf("errs: %v", errs))
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs["A"], HasError, validator.ErrZeroValue)
 	c.Assert(errs["B"], HasError, validator.ErrLen)
 	c.Assert(errs["B"], HasError, validator.ErrMin)
@@ -183,8 +187,10 @@ func (ms *MySuite) TestUnknownTag(c *C) {
 		A int `validate:"foo"`
 	}
 	t := test{}
-	valid, errs := validator.Validate(t)
-	c.Assert(valid, Equals, false)
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 1)
 	c.Assert(errs["A"], HasError, validator.ErrUnknownTag)
 }
@@ -195,8 +201,10 @@ func (ms *MySuite) TestUnsupported(c *C) {
 		B float64 `validate:"regexp=.*"`
 	}
 	t := test{}
-	valid, errs := validator.Validate(t)
-	c.Assert(valid, Equals, false)
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 2)
 	c.Assert(errs["A"], HasError, validator.ErrUnsupported)
 	c.Assert(errs["B"], HasError, validator.ErrUnsupported)
@@ -209,8 +217,10 @@ func (ms *MySuite) TestBadParameter(c *C) {
 		C string `validate:"max=foo"`
 	}
 	t := test{}
-	valid, errs := validator.Validate(t)
-	c.Assert(valid, Equals, false)
+	err := validator.Validate(t)
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 3)
 	c.Assert(errs["A"], HasError, validator.ErrBadParameter)
 	c.Assert(errs["B"], HasError, validator.ErrBadParameter)

--- a/validator_test.go
+++ b/validator_test.go
@@ -75,15 +75,20 @@ func (ms *MySuite) TestValidate(c *C) {
 
 func (ms *MySuite) TestValidSlice(c *C) {
 	s := make([]int, 0, 10)
-	valid, errs := validator.Valid(s, "nonzero")
-	c.Assert(valid, Equals, false)
+	err := validator.Valid(s, "nonzero")
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrZeroValue)
 
 	for i := 0; i < 10; i++ {
 		s = append(s, i)
 	}
 
-	_, errs = validator.Valid(s, "min=11,max=5,len=9,nonzero")
+	err = validator.Valid(s, "min=11,max=5,len=9,nonzero")
+	c.Assert(err, NotNil)
+	errs, ok = err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrMin)
 	c.Assert(errs, HasError, validator.ErrMax)
 	c.Assert(errs, HasError, validator.ErrLen)
@@ -92,19 +97,27 @@ func (ms *MySuite) TestValidSlice(c *C) {
 
 func (ms *MySuite) TestValidMap(c *C) {
 	m := make(map[string]string)
-	valid, errs := validator.Valid(m, "nonzero")
-	c.Assert(valid, Equals, false)
+	err := validator.Valid(m, "nonzero")
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrZeroValue)
 
-	_, errs = validator.Valid(m, "min=1")
+	err = validator.Valid(m, "min=1")
+	c.Assert(err, NotNil)
+	errs, ok = err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrMin)
 
 	m = map[string]string{"A": "a", "B": "a"}
-	_, errs = validator.Valid(m, "max=1")
+	err = validator.Valid(m, "max=1")
+	c.Assert(err, NotNil)
+	errs, ok = err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrMax)
 
-	valid, _ = validator.Valid(m, "min=2, max=5")
-	c.Assert(valid, Equals, true)
+	err = validator.Valid(m, "min=2, max=5")
+	c.Assert(err, IsNil)
 
 	m = map[string]string{
 		"1": "a",
@@ -113,8 +126,10 @@ func (ms *MySuite) TestValidMap(c *C) {
 		"4": "d",
 		"5": "e",
 	}
-	valid, errs = validator.Valid(m, "len=4,min=6,max=1,nonzero")
-	c.Assert(valid, Equals, false)
+	err = validator.Valid(m, "len=4,min=6,max=1,nonzero")
+	c.Assert(err, NotNil)
+	errs, ok = err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrLen)
 	c.Assert(errs, HasError, validator.ErrMin)
 	c.Assert(errs, HasError, validator.ErrMax)
@@ -123,49 +138,59 @@ func (ms *MySuite) TestValidMap(c *C) {
 }
 
 func (ms *MySuite) TestValidFloat(c *C) {
-	valid, _ := validator.Valid(12.34, "nonzero")
-	c.Assert(valid, Equals, true)
+	err := validator.Valid(12.34, "nonzero")
+	c.Assert(err, IsNil)
 
-	valid, errs := validator.Valid(0.0, "nonzero")
-	c.Assert(valid, Equals, false)
+	err = validator.Valid(0.0, "nonzero")
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrZeroValue)
 }
 
 func (ms *MySuite) TestValidInt(c *C) {
 	i := 123
-	valid, errs := validator.Valid(i, "nonzero")
-	c.Assert(valid, Equals, true)
-	c.Assert(errs, Not(HasError), validator.ErrZeroValue)
+	err := validator.Valid(i, "nonzero")
+	c.Assert(err, IsNil)
 
-	valid, _ = validator.Valid(i, "min=1")
-	c.Assert(valid, Equals, true)
+	err = validator.Valid(i, "min=1")
+	c.Assert(err, IsNil)
 
-	valid, errs = validator.Valid(i, "min=124, max=122")
-	c.Assert(valid, Equals, false)
+	err = validator.Valid(i, "min=124, max=122")
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrMin)
 	c.Assert(errs, HasError, validator.ErrMax)
 
-	_, errs = validator.Valid(i, "max=10")
+	err = validator.Valid(i, "max=10")
+	c.Assert(err, NotNil)
+	errs, ok = err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrMax)
 }
 
 func (ms *MySuite) TestValidString(c *C) {
 	s := "test1234"
-	valid, errs := validator.Valid(s, "len=8")
-	c.Assert(valid, Equals, true)
-	c.Assert(errs, HasLen, 0)
+	err := validator.Valid(s, "len=8")
+	c.Assert(err, IsNil)
 
-	_, errs = validator.Valid(s, "len=0")
+	err = validator.Valid(s, "len=0")
+	c.Assert(err, NotNil)
+	errs, ok := err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasError, validator.ErrLen)
 
-	_, errs = validator.Valid(s, "regexp=^[tes]{4}.*")
-	c.Assert(errs, HasLen, 0)
+	err = validator.Valid(s, "regexp=^[tes]{4}.*")
+	c.Assert(err, IsNil)
 
-	_, errs = validator.Valid(s, "regexp=^.*[0-9]{5}$")
+	err = validator.Valid(s, "regexp=^.*[0-9]{5}$")
 	c.Assert(errs, NotNil)
 
-	valid, errs = validator.Valid("", "nonzero,len=3,max=1")
-	c.Assert(valid, Equals, false)
+	err = validator.Valid("", "nonzero,len=3,max=1")
+	c.Assert(err, NotNil)
+	errs, ok = err.(validator.ErrorArray)
+	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 2)
 	c.Assert(errs, HasError, validator.ErrZeroValue)
 	c.Assert(errs, HasError, validator.ErrLen)
@@ -177,9 +202,8 @@ func (ms *MySuite) TestValidateStructVar(c *C) {
 		A int
 	}
 	t := test{}
-	valid, errs := validator.Valid(t, "")
-	c.Assert(valid, Equals, false)
-	c.Assert(errs, HasError, validator.ErrUnsupported)
+	err := validator.Valid(t, "")
+	c.Assert(err, Equals, validator.ErrUnsupported)
 }
 
 func (ms *MySuite) TestUnknownTag(c *C) {
@@ -237,9 +261,9 @@ func (c *hasErrorChecker) Check(params []interface{}, names []string) (bool, str
 		slice []error
 		value error
 	)
-	slice, ok = params[0].([]error)
+	slice, ok = params[0].(validator.ErrorArray)
 	if !ok {
-		return false, "First parameter is not a []error"
+		return false, "First parameter is not an Errorarray"
 	}
 	value, ok = params[1].(error)
 	if !ok {

--- a/validator_test.go
+++ b/validator_test.go
@@ -18,6 +18,7 @@ package validator_test
 
 import (
 	"testing"
+
 	. "gopkg.in/check.v1"
 
 	"gopkg.in/validator.v1"
@@ -176,6 +177,20 @@ func (ms *MySuite) TestValidateStructVar(c *C) {
 	valid, errs := validator.Valid(t, "")
 	c.Assert(valid, Equals, false)
 	c.Assert(errs, HasError, validator.ErrUnsupported)
+}
+
+func (ms *MySuite) TestValidateOmittedStructVar(c *C) {
+	type test2 struct {
+		B int `validate:min=1`
+	}
+	type test1 struct {
+		A test2 `validate:"-"`
+	}
+
+	t := test1{}
+	valid, errs := validator.Validate(t)
+	c.Assert(valid, Equals, true)
+	c.Assert(errs, HasLen, 0)
 }
 
 func (ms *MySuite) TestUnknownTag(c *C) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -313,6 +313,20 @@ func (ms *MySuite) TestValidatePointerVar(c *C) {
 
 	err = validator.Validate(&test6{&test2{}})
 	c.Assert(err, IsNil)
+
+	type test7 struct {
+		A *string `validate:"min=6"`
+		B *int    `validate:"len=7"`
+		C *int    `validate:"min=12"`
+	}
+	s := "aaa"
+	b := 8
+	err = validator.Validate(&test7{&s, &b, nil})
+	errs, ok = err.(validator.ErrorMap)
+	c.Assert(ok, Equals, true)
+	c.Assert(errs["A"], HasError, validator.ErrMin)
+	c.Assert(errs["B"], HasError, validator.ErrLen)
+	c.Assert(errs["C"], Not(HasError), validator.ErrMin)
 }
 
 func (ms *MySuite) TestValidateOmittedStructVar(c *C) {


### PR DESCRIPTION
I'm Chinese. When I want to set ``` test string `validate:"max=10"` ```, len() can't work exactly.
if using len(), One character in Chinese will get three bytes. But One character in English will get 1 byte.

"utf8.RuneCountInString()" works well.

