### PR TITLE
Move field names to callback

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -292,10 +292,15 @@ func (mv *Validator) deepValidateCollection(f reflect.Value, m ErrorMap, fnameFn
 			}
 		}
 	case reflect.Array, reflect.Slice:
-		for i := 0; i < f.Len(); i++ {
-			mv.deepValidateCollection(f.Index(i), m, func() string {
-				return fmt.Sprintf("%s[%d]", fnameFn(), i)
-			})
+		// we don't need to loop over every byte in a byte slice so we only end up
+		// looping when the kind is something we care about
+		switch f.Type().Elem().Kind() {
+		case reflect.Struct, reflect.Interface, reflect.Ptr, reflect.Map, reflect.Array, reflect.Slice:
+			for i := 0; i < f.Len(); i++ {
+				mv.deepValidateCollection(f.Index(i), m, func() string {
+					return fmt.Sprintf("%s[%d]", fnameFn(), i)
+				})
+			}
 		}
 	case reflect.Map:
 		for _, key := range f.MapKeys() {

--- a/validator_test.go
+++ b/validator_test.go
@@ -569,6 +569,18 @@ func (ms *MySuite) TestPrivateFields(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (ms *MySuite) TestValidateStructWithByteSliceSlice(c *C) {
+	type test struct {
+		Slices [][]byte `validate:"len=1"`
+	}
+
+	t := test{
+		Slices: [][]byte{[]byte(``)},
+	}
+	err := validator.Validate(t)
+	c.Assert(err, IsNil)
+}
+
 type hasErrorChecker struct {
 	*CheckerInfo
 }


### PR DESCRIPTION
We were calling fmt.Sprintf to get the field name on every single field
when its really only needed if an error happens so instead pass a
callback.

Fixes #78