### PR TITLE
Fix errors string serialization

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -85,12 +85,11 @@ func (err ErrorMap) Error() string {
 
 	for k, errs := range err {
 		if len(errs) > 0 {
-			b.WriteString(fmt.Sprintf("%s: %s ", k, errs.Error()))
+			b.WriteString(fmt.Sprintf("%s: %s, ", k, errs.Error()))
 		}
 	}
 
-	// return strings.TrimSuffix(b.String(), ",")
-	return b.String()
+	return strings.TrimSuffix(b.String(), ", ")
 }
 
 // ErrorArray is a slice of errors returned by the Validate function.

--- a/validator_test.go
+++ b/validator_test.go
@@ -19,6 +19,8 @@ package validator_test
 import (
 	"fmt"
 	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -649,8 +651,15 @@ func (ms *MySuite) TestErrors(c *C) {
 			fmt.Errorf("qux"),
 		},
 	}
+	sep := ", "
 	expected := "foo: bar, baz: qux"
-	c.Assert(expected, Equals, err.Error())
+
+	errString := err.Error()
+	expectedParts := strings.Split(expected, sep)
+	sort.Strings(expectedParts)
+	errStringParts := strings.Split(errString, sep)
+	sort.Strings(errStringParts)
+	c.Assert(expectedParts, Equals, errStringParts)
 }
 
 type hasErrorChecker struct {

--- a/validator_test.go
+++ b/validator_test.go
@@ -17,6 +17,7 @@
 package validator_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -637,6 +638,19 @@ func (ms *MySuite) TestEmbeddedInterface(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(errs, HasLen, 1)
 	c.Assert(errs["I"], HasError, validator.ErrZeroValue)
+}
+
+func (ms *MySuite) TestErrors(c *C) {
+	err := validator.ErrorMap{
+		"foo": validator.ErrorArray{
+			fmt.Errorf("bar"),
+		},
+		"baz": validator.ErrorArray{
+			fmt.Errorf("qux"),
+		},
+	}
+	expected := "foo: bar, baz: qux"
+	c.Assert(expected, Equals, err.Error())
 }
 
 type hasErrorChecker struct {

--- a/validator_test.go
+++ b/validator_test.go
@@ -654,12 +654,14 @@ func (ms *MySuite) TestErrors(c *C) {
 	sep := ", "
 	expected := "foo: bar, baz: qux"
 
-	errString := err.Error()
 	expectedParts := strings.Split(expected, sep)
 	sort.Strings(expectedParts)
+
+	errString := err.Error()
 	errStringParts := strings.Split(errString, sep)
 	sort.Strings(errStringParts)
-	c.Assert(expectedParts, Equals, errStringParts)
+
+	c.Assert(expectedParts, DeepEquals, errStringParts)
 }
 
 type hasErrorChecker struct {


### PR DESCRIPTION
This PR fixes the string serialization for `ErrorMap`s in the `Error()` function, which now returns a string with no separating commas, as well as a trailing whitespace.

This fixes it by returning a comma-separated list of errors, with trimmed spaces.