### PR TITLE
fix: json print does not properly work on field names of internal structs

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -305,7 +305,15 @@ func (mv *Validator) validateField(fieldDef reflect.StructField, fieldVal reflec
 
 	// no-op if field is not a struct, interface, array, slice or map
 	mv.deepValidateCollection(fieldVal, m, func() string {
-		return fieldDef.Name
+		n := fieldDef.Name
+
+		if mv.printJSON {
+			if jn := parseName(fieldDef.Tag.Get("json")); jn != "" {
+				n = jn
+			}
+		}
+
+		return n
 	})
 
 	if len(errs) > 0 {


### PR DESCRIPTION
When using printJson(true), there was a bug when the field name would still be used when checking structs recursively.